### PR TITLE
fix(lua52): make get_html_form compatible with lua5.2

### DIFF
--- a/mod_push_appserver/mod_push_appserver.lua
+++ b/mod_push_appserver/mod_push_appserver.lua
@@ -115,7 +115,8 @@ end
 
 local function get_html_form(...)
 	local html = '<form method="post"><table>\n';
-	for i,v in ipairs(arg) do
+	local fields = arg ~= nil and arg or {...}
+	for i,v in ipairs(fields) do
 		html = html..'<tr><td>'..tostring(v)..'</td><td><input type="text" name="'..tostring(v)..'" required></td></tr>\n';
 	end
 	html = html..'<tr><td>&nbsp;</td><td><button type="submit">send request</button></td></tr>\n</table></form>';

--- a/mod_push_appserver/mod_push_appserver.lua
+++ b/mod_push_appserver/mod_push_appserver.lua
@@ -115,8 +115,7 @@ end
 
 local function get_html_form(...)
 	local html = '<form method="post"><table>\n';
-	local fields = arg ~= nil and arg or {...}
-	for i,v in ipairs(fields) do
+	for i,v in ipairs{...} do
 		html = html..'<tr><td>'..tostring(v)..'</td><td><input type="text" name="'..tostring(v)..'" required></td></tr>\n';
 	end
 	html = html..'<tr><td>&nbsp;</td><td><button type="submit">send request</button></td></tr>\n</table></form>';


### PR DESCRIPTION
~~Create the fields table from `arg` or `...` depending on which is not
`nil`.  On lua5.2 `arg` will be `nil`.~~

Just iterate over `{...}` as it's both compatible with Lua 5.1 and 5.2.

Fixes #11